### PR TITLE
fix: Ensure version passed as config into token is a string

### DIFF
--- a/src/android.tsx
+++ b/src/android.tsx
@@ -40,7 +40,7 @@ export const AtomicAndroid = {
   }): void {
     config.platform = {
       name: 'android',
-      version: Platform.Version
+      version: Platform.Version.toString()
     }
 
     _addEventListener('onClose', onClose)

--- a/src/ios.tsx
+++ b/src/ios.tsx
@@ -20,7 +20,7 @@ export const AtomicIOS = {
   }): void {
     config.platform = {
       name: 'ios',
-      version: Platform.Version
+      version: Platform.Version.toString()
     }
 
     const TransactSdkEvents = new NativeEventEmitter(TransactSdk)


### PR DESCRIPTION
This [commit](https://github.com/atomicfi/atomic-transact-react-native/commit/902e07fad13a05b7745ec325ea97c5be04a4a2bf) introduced a bug as it expects `Platform.Version` to be a string, but it is typed as `string | number` by `react-native`. This ensures it is parsed as a string before inserting it into the token.

Fixes #7