### PR TITLE
feat: user actions

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 2,
+  "singleQuote": true,
+  "semi": false
+}

--- a/atomicfi-transact-react-native.podspec
+++ b/atomicfi-transact-react-native.podspec
@@ -20,10 +20,10 @@ Pod::Spec.new do |s|
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)
-    s.dependency "AtomicSDK", "3.8.4"
+    s.dependency "AtomicSDK", "3.8.10"
   else
     s.dependency "React-Core"
-    s.dependency "AtomicSDK", "3.8.4"
+    s.dependency "AtomicSDK", "3.8.10"
 
     # Don't install the dependencies when we run `pod install` in the old architecture.
     if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then

--- a/ios/TransactReactNative.m
+++ b/ios/TransactReactNative.m
@@ -9,6 +9,11 @@ RCT_EXTERN_METHOD(presentTransact:(NSDictionary *)config
 				  withResolver:(RCTPromiseResolveBlock)resolve
 				  withRejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(presentAction:(NSString *)id
+				  environment:NSString
+				  withResolver:(RCTPromiseResolveBlock)resolve
+				  withRejecter:(RCTPromiseRejectBlock)reject)
+
 + (BOOL)requiresMainQueueSetup
 {
   return NO;

--- a/ios/TransactReactNative.swift
+++ b/ios/TransactReactNative.swift
@@ -52,8 +52,12 @@ class TransactReactNative: RCTEventEmitter {
             guard let source = RCTPresentedViewController() else { return }
 
             do {
-                Atomic.presentAction(from: source, id: id, environment: .custom(path: environment))
-                resolve([])
+                Atomic.presentAction(from: source, id: id, environment: .custom(path: environment), onLaunch: { 
+                    self.sendEvent(withName: "onLaunch", body: [])
+                }, onCompletion: {
+                    self.sendEvent(withName: "onCompletion", body: [])
+                })
+				resolve([])
             }
             catch let error {
                 reject("config error", String(describing: error), NSError(domain: "com.atomicfi", code: 500, userInfo: nil))

--- a/ios/TransactReactNative.swift
+++ b/ios/TransactReactNative.swift
@@ -46,6 +46,21 @@ class TransactReactNative: RCTEventEmitter {
 		}
     }
 
+    @objc(presentAction:environment:withResolver:withRejecter:)
+    func presentAction(id: String, environment: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+        DispatchQueue.main.async {
+            guard let source = RCTPresentedViewController() else { return }
+
+            do {
+                Atomic.presentAction(from: source, id: id, environment: .custom(path: environment))
+                resolve([])
+            }
+            catch let error {
+                reject("config error", String(describing: error), NSError(domain: "com.atomicfi", code: 500, userInfo: nil))
+            }
+        }
+    }
+
 	@objc override func supportedEvents() -> [String] {
 		return ["onInteraction", "onDataRequest"]
 	}

--- a/ios/TransactReactNative.swift
+++ b/ios/TransactReactNative.swift
@@ -66,7 +66,7 @@ class TransactReactNative: RCTEventEmitter {
     }
 
 	@objc override func supportedEvents() -> [String] {
-		return ["onInteraction", "onDataRequest"]
+		return ["onInteraction", "onDataRequest", "onLaunch", "onCompletion"]
 	}
 
 	@objc override static func requiresMainQueueSetup() -> Bool {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  tabWidth: 2,
-  semi: false,
-  singleQuote: true,
-};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,4 +101,28 @@ export const Atomic = {
         throw new Error(`Unsupported OS: ${Platform.OS}`);
     }
   },
+  presentAction({
+    id,
+    environment,
+  }: {
+    id: String;
+    environment?: String;
+  }): void {
+    const args = {
+      TransactReactNative,
+      id,
+      environment: environment || CONSTANTS.Environment.Production,
+    };
+
+    switch (Platform.OS) {
+      case 'ios':
+        AtomicIOS.presentAction(args);
+        break;
+      // case 'android':
+      //   AtomicAndroid.transact(args);
+      //   break;
+      default:
+        throw new Error(`Unsupported OS: ${Platform.OS}`);
+    }
+  },
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,14 +104,20 @@ export const Atomic = {
   presentAction({
     id,
     environment,
+    onLaunch,
+    onCompletion,
   }: {
     id: String;
     environment?: String;
+    onLaunch?: Function;
+    onCompletion?: Function;
   }): void {
     const args = {
       TransactReactNative,
       id,
       environment: environment || CONSTANTS.Environment.Production,
+      onLaunch,
+      onCompletion,
     };
 
     switch (Platform.OS) {

--- a/src/ios.tsx
+++ b/src/ios.tsx
@@ -1,4 +1,12 @@
-import { NativeEventEmitter } from 'react-native';
+import { EmitterSubscription, NativeEventEmitter } from 'react-native';
+
+let presentActionListeners: {
+  onLaunch?: EmitterSubscription;
+  onCompletion?: EmitterSubscription;
+} = {
+  onLaunch: undefined,
+  onCompletion: undefined,
+};
 
 export const AtomicIOS = {
   transact({
@@ -59,11 +67,41 @@ export const AtomicIOS = {
     TransactReactNative,
     id,
     environment,
+    onLaunch,
+    onCompletion,
   }: {
     TransactReactNative: any;
     id: String;
     environment?: String;
+    onLaunch?: Function;
+    onCompletion?: Function;
   }): void {
+    const TransactReactNativeEvents = new NativeEventEmitter(
+      TransactReactNative
+    );
+
+    if (presentActionListeners.onLaunch) {
+      presentActionListeners.onLaunch.remove();
+    }
+
+    if (presentActionListeners.onCompletion) {
+      presentActionListeners.onCompletion.remove();
+    }
+
+    if (onLaunch) {
+      presentActionListeners.onLaunch = TransactReactNativeEvents.addListener(
+        'onLaunch',
+        () => onLaunch()
+      );
+    }
+
+    if (onCompletion) {
+      presentActionListeners.onCompletion =
+        TransactReactNativeEvents.addListener('onCompletion', () =>
+          onCompletion()
+        );
+    }
+
     TransactReactNative.presentAction(id, environment);
   },
 };

--- a/src/ios.tsx
+++ b/src/ios.tsx
@@ -18,7 +18,9 @@ export const AtomicIOS = {
     onFinish?: Function;
     onClose?: Function;
   }): void {
-    const TransactReactNativeEvents = new NativeEventEmitter(TransactReactNative);
+    const TransactReactNativeEvents = new NativeEventEmitter(
+      TransactReactNative
+    );
     let onInteractionListener: any = undefined;
     let onDataRequestListener: any = undefined;
 
@@ -41,14 +43,27 @@ export const AtomicIOS = {
       );
     }
 
-    TransactReactNative.presentTransact(config, environment).then((event: any) => {
-      if (event.finished && onFinish) {
-        removeListeners();
-        onFinish(event.finished);
-      } else if (event.closed && onClose) {
-        removeListeners();
-        onClose(event.closed);
+    TransactReactNative.presentTransact(config, environment).then(
+      (event: any) => {
+        if (event.finished && onFinish) {
+          removeListeners();
+          onFinish(event.finished);
+        } else if (event.closed && onClose) {
+          removeListeners();
+          onClose(event.closed);
+        }
       }
-    });
+    );
+  },
+  presentAction({
+    TransactReactNative,
+    id,
+    environment,
+  }: {
+    TransactReactNative: any;
+    id: String;
+    environment?: String;
+  }): void {
+    TransactReactNative.presentAction(id, environment);
   },
 };


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/SUB-34/detect-when-action-was-launched

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [x] New and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
