### PR TITLE
chore: bump iOS dependency to 3.8.16

### DIFF
--- a/atomicfi-transact-react-native.podspec
+++ b/atomicfi-transact-react-native.podspec
@@ -20,10 +20,10 @@ Pod::Spec.new do |s|
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)
-    s.dependency "AtomicSDK", "3.8.14"
+    s.dependency "AtomicSDK", "3.8.16"
   else
     s.dependency "React-Core"
-    s.dependency "AtomicSDK", "3.8.14"
+    s.dependency "AtomicSDK", "3.8.16"
 
     # Don't install the dependencies when we run `pod install` in the old architecture.
     if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - atomicfi-transact-react-native (3.7.1):
-    - AtomicSDK (= 3.8.14)
+  - atomicfi-transact-react-native (3.7.2):
+    - AtomicSDK (= 3.8.16)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.01.01.00)
@@ -21,17 +21,17 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - AtomicSDK (3.8.14):
+  - AtomicSDK (3.8.16):
     - QuantumIOS
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.74.5)
   - fmt (9.1.0)
   - glog (0.3.5)
-  - QuantumIOS (3.6.4):
-    - QuantumIOS/QuantumIOS (= 3.6.4)
-  - QuantumIOS/MuppetIOS (3.6.4)
-  - QuantumIOS/QuantumIOS (3.6.4):
+  - QuantumIOS (3.8.16):
+    - QuantumIOS/QuantumIOS (= 3.8.16)
+  - QuantumIOS/MuppetIOS (3.8.16)
+  - QuantumIOS/QuantumIOS (3.8.16):
     - QuantumIOS/MuppetIOS
   - RCT-Folly (2024.01.01.00):
     - boost
@@ -1358,14 +1358,14 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  atomicfi-transact-react-native: 92e76813cbef2b181c34e8737168d8c5cb1560a7
-  AtomicSDK: 09e0bfcf30366b4cbf01e8ab1abe1105aa25b01f
+  atomicfi-transact-react-native: 2bf4962a13c13bc9ba2ce9ccbb8e486aa11e2fbf
+  AtomicSDK: 3326f9e5bb120502cd916780f0e45c7f87efe7ad
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   FBLazyVector: ac12dc084d1c8ec4cc4d7b3cf1b0ebda6dab85af
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
-  QuantumIOS: c6292f59e7b0a9fe430fdfb06d1b99864164f5d5
+  QuantumIOS: c86090b4a518ad991af9a133e3eb2d4b19914a1b
   RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
   RCTDeprecation: 3afceddffa65aee666dafd6f0116f1d975db1584
   RCTRequired: ec1239bc9d8bf63e10fb92bd8b26171a9258e0c1
@@ -1420,4 +1420,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 613fafe8f331eed82dc92f9504a9c682b3c8f0c6
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.16.0


### PR DESCRIPTION

# Linear Link

https://linear.app/atomicbuilt/issue/MGMT-48/allow-transact-webview-to-be-shown-hidden-via-transact


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [x] New and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
