### PR TITLE
chore: bump ios SDK to 3.9.4

### DIFF
--- a/atomicfi-transact-react-native.podspec
+++ b/atomicfi-transact-react-native.podspec
@@ -20,10 +20,10 @@ Pod::Spec.new do |s|
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)
-    s.dependency "AtomicSDK", "3.9.1"
+    s.dependency "AtomicSDK", "3.9.4"
   else
     s.dependency "React-Core"
-    s.dependency "AtomicSDK", "3.9.1"
+    s.dependency "AtomicSDK", "3.9.4"
 
     # Don't install the dependencies when we run `pod install` in the old architecture.
     if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - atomicfi-transact-react-native (3.8.0):
-    - AtomicSDK (= 3.9.1)
+  - atomicfi-transact-react-native (3.8.1):
+    - AtomicSDK (= 3.9.4)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.01.01.00)
@@ -21,17 +21,17 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - AtomicSDK (3.9.1):
+  - AtomicSDK (3.9.4):
     - QuantumIOS
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.74.5)
   - fmt (9.1.0)
   - glog (0.3.5)
-  - QuantumIOS (3.9.2):
-    - QuantumIOS/QuantumIOS (= 3.9.2)
-  - QuantumIOS/MuppetIOS (3.9.2)
-  - QuantumIOS/QuantumIOS (3.9.2):
+  - QuantumIOS (3.9.4):
+    - QuantumIOS/QuantumIOS (= 3.9.4)
+  - QuantumIOS/MuppetIOS (3.9.4)
+  - QuantumIOS/QuantumIOS (3.9.4):
     - QuantumIOS/MuppetIOS
   - RCT-Folly (2024.01.01.00):
     - boost
@@ -1358,14 +1358,14 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  atomicfi-transact-react-native: 8dc77bc51e687e5a5b77c643943768b3f22c7dad
-  AtomicSDK: 68a3a0ad1935c0719cb6235339aaae082492ce26
+  atomicfi-transact-react-native: 8fb87ca56ca4a8c0c3df60479319787b76965080
+  AtomicSDK: fe431e6fbcba682888ef450d5e477f8cd6e1890b
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   FBLazyVector: ac12dc084d1c8ec4cc4d7b3cf1b0ebda6dab85af
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
-  QuantumIOS: 89d095fc02a3d3e75f28dc737c0964b03a241977
+  QuantumIOS: 74a269891f367a39e8cf0b97c836f61cf8b2bbc8
   RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
   RCTDeprecation: 3afceddffa65aee666dafd6f0116f1d975db1584
   RCTRequired: ec1239bc9d8bf63e10fb92bd8b26171a9258e0c1


### PR DESCRIPTION


# Linear Link

https://linear.app/atomicbuilt/issue/MGMT-206/bump-rn-sdk-to-394

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [x] New and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
