### PR TITLE
feat: add onTaskStatusUpdate & onAuthStatusUpdate callbacks

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 // Update this value to the latest Android SDK version published on Maven
-def transact_version = "3.6.1"
+def transact_version = "3.8.0"
 
 android {
   namespace "com.atomicfi.transactreactnative"

--- a/android/src/main/java/com/atomicfi/transactreactnative/TransactReactNativeModule.kt
+++ b/android/src/main/java/com/atomicfi/transactreactnative/TransactReactNativeModule.kt
@@ -31,8 +31,6 @@ class TransactReactNativeModule(reactContext: ReactApplicationContext) :
     eventName: String,
     data: JSONObject,
     fieldName: String,
-    receiver: TransactBroadcastReceiver,
-    context: Context,
     emitter: DeviceEventManagerModule.RCTDeviceEventEmitter,
     promise: Promise
   ) {
@@ -41,7 +39,6 @@ class TransactReactNativeModule(reactContext: ReactApplicationContext) :
       putString(fieldName, value)
     }
 
-    Transact.unregisterReceiver(context, receiver)
     emitter.emit(eventName, data.toString())
     promise.resolve(result)
   }
@@ -55,11 +52,11 @@ class TransactReactNativeModule(reactContext: ReactApplicationContext) :
     try {
       Transact.present(context, config, object : TransactBroadcastReceiver() {
         override fun onClose(data: JSONObject) {
-          handleCallbackEvent("onClose", data, "reason", this, context, emitter, promise)
+          handleCallbackEvent("onClose", data, "reason", emitter, promise)
         }
 
         override fun onFinish(data: JSONObject) {
-          handleCallbackEvent("onFinish", data, "taskId", this, context, emitter, promise)
+          handleCallbackEvent("onFinish", data, "taskId", emitter, promise)
         }
 
         override fun onInteraction(data: JSONObject) {
@@ -68,6 +65,14 @@ class TransactReactNativeModule(reactContext: ReactApplicationContext) :
 
         override fun onDataRequest(data: JSONObject) {
           emitter.emit("onDataRequest", data.toString())
+        }
+
+        override fun onAuthStatusUpdate(data: JSONObject) {
+          emitter.emit("onAuthStatusUpdate", data.toString())
+        }
+
+        override fun onTaskStatusUpdate(data: JSONObject) {
+          emitter.emit("onTaskStatusUpdate", data.toString())
         }
       })
     } catch (e: Exception) {
@@ -91,15 +96,23 @@ class TransactReactNativeModule(reactContext: ReactApplicationContext) :
 
       val receiver = object : TransactBroadcastReceiver() {
         override fun onClose(data: JSONObject) {
-          handleCallbackEvent("onClose", data, "reason", this, context, emitter, promise)
+          handleCallbackEvent("onClose", data, "reason", emitter, promise)
         }
 
         override fun onFinish(data: JSONObject) {
-          handleCallbackEvent("onFinish", data, "taskId", this, context, emitter, promise)
+          handleCallbackEvent("onFinish", data, "taskId", emitter, promise)
         }
 
         override fun onLaunch() {
           emitter.emit("onLaunch", null)
+        }
+
+        override fun onAuthStatusUpdate(data: JSONObject) {
+          emitter.emit("onAuthStatusUpdate", data.toString())
+        }
+
+        override fun onTaskStatusUpdate(data: JSONObject) {
+          emitter.emit("onTaskStatusUpdate", data.toString())
         }
       }
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 
 import { StyleSheet, View, Button } from 'react-native';
-import { Atomic, Product } from '@atomicfi/transact-react-native';
+import { Atomic, Product, Scope } from '@atomicfi/transact-react-native';
 
 export default function App() {
   function presentTransact() {
     Atomic.transact({
       config: {
-        product: Product.DEPOSIT,
+        product: Product.SWITCH,
+        scope: Scope.PAYLINK,
         publicToken: '',
       },
       onInteraction: (interaction: any) => {
@@ -15,6 +16,12 @@ export default function App() {
       },
       onDataRequest: (request: any) => {
         console.log('Data request event:', request);
+      },
+      onAuthStatusUpdate: (authStatus: any) => {
+        console.log('Auth status update event:', authStatus);
+      },
+      onTaskStatusUpdate: (taskStatus: any) => {
+        console.log('Task status update event:', taskStatus);
       },
       onFinish: (data: any) => {
         console.log('Finish event:', data);
@@ -36,6 +43,12 @@ export default function App() {
       },
       onDataRequest: (request: any) => {
         console.log('Data request event:', request);
+      },
+      onAuthStatusUpdate: (authStatus: any) => {
+        console.log('Auth status update event:', authStatus);
+      },
+      onTaskStatusUpdate: (taskStatus: any) => {
+        console.log('Task status update event:', taskStatus);
       },
       onFinish: (data: any) => {
         console.log('Finish event:', data);

--- a/ios/TransactReactNative.swift
+++ b/ios/TransactReactNative.swift
@@ -3,31 +3,80 @@ import UIKit
 
 @objc(TransactReactNative)
 class TransactReactNative: RCTEventEmitter {
-
+	
 	@objc(presentTransact:environment:withResolver:withRejecter:)
 	func presentTransact(config: [String: Any], environment: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
 		DispatchQueue.main.async {
 			guard let source = RCTPresentedViewController() else { return }
-
+			
 			let decoder = JSONDecoder()
-
+			
 			do {
 				var json = config
-
+				
 				if var platform = AtomicConfig.Platform().encode() as? [String: Any] {
-                    platform["sdkVersion"] = platform["sdkVersion"] as! String + "-react"
-                    json["platform"] = platform
+					platform["sdkVersion"] = platform["sdkVersion"] as! String + "-react"
+					json["platform"] = platform
 				}
-
-                guard let data = try? JSONSerialization.data(withJSONObject: json, options: []) else { return }
-
-                let config = try decoder.decode(AtomicConfig.self, from: data)
-
-				Atomic.presentTransact(from: source, config: config, environment: .custom(path: environment), onInteraction: { interaction in
-					self.sendEvent(withName: "onInteraction", body: ["name": interaction.name, "value": interaction.value])
-				}, onDataRequest: { request in
-					self.sendEvent(withName: "onDataRequest", body: request.data)
-				}, onCompletion: { result in
+				
+				guard let data = try? JSONSerialization.data(withJSONObject: json, options: []) else { return }
+				
+				let config = try decoder.decode(AtomicConfig.self, from: data)
+				
+				Atomic.presentTransact(
+					from: source, config: config, environment: .custom(path: environment),
+					onInteraction: { interaction in
+						self.sendEvent(withName: "onInteraction", body: ["name": interaction.name, "value": interaction.value])
+					},
+					onDataRequest: { request in
+						self.sendEvent(withName: "onDataRequest", body: request.data)
+					},
+					onAuthStatusUpdate: { status in
+						self.sendEvent(withName: "onAuthStatusUpdate", body: ["status": status.serialize()])
+					},
+					onTaskStatusUpdate: { status in
+						self.sendEvent(withName: "onTaskStatusUpdate", body: ["status":  status.serialize()])
+					},
+					onCompletion: { result in
+						switch result {
+						case .finished(let response):
+							resolve(["finished": response.data])
+						case .closed(let response):
+							resolve(["closed": response.data])
+						case .error:
+							resolve(["error": "Unknown error"])
+						default:
+							resolve(["error": "Unknown error"])
+						}
+					}
+				)
+			}
+			catch let error {
+				reject("config error", String(describing: error), NSError(domain: "com.atomicfi", code: 500, userInfo: nil))
+			}
+		}
+	}
+	
+	@objc(presentAction:environment:withResolver:withRejecter:)
+	func presentAction(id: String, environment: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+		DispatchQueue.main.async {
+			guard let source = RCTPresentedViewController() else { return }
+			
+			Atomic.presentAction(
+				from: source,
+				id: id,
+				environment: .custom(path: environment),
+				onLaunch: {
+					self.sendEvent(withName: "onLaunch", body: [])
+				},
+				onAuthStatusUpdate: { status in
+					self.sendEvent(withName: "onAuthStatusUpdate", body: ["status": status.serialize()])
+				},
+				onTaskStatusUpdate: { status in
+					print("iOS Native -> Task status update event:", status)
+					self.sendEvent(withName: "onTaskStatusUpdate", body: ["status": status.serialize()])
+				},
+				onCompletion: { result in
 					switch result {
 					case .finished(let response):
 						resolve(["finished": response.data])
@@ -36,44 +85,99 @@ class TransactReactNative: RCTEventEmitter {
 					case .error:
 						resolve(["error": "Unknown error"])
 					default:
+						print("default")
 						resolve(["error": "Unknown error"])
 					}
-				})
-			}
-			catch let error {
-				reject("config error", String(describing: error), NSError(domain: "com.atomicfi", code: 500, userInfo: nil))
-			}
-		}
-    }
-
-    @objc(presentAction:environment:withResolver:withRejecter:)
-	func presentAction(id: String, environment: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
-		DispatchQueue.main.async {
-			guard let source = RCTPresentedViewController() else { return }
-			
-			Atomic.presentAction(from: source, id: id, environment: .custom(path: environment), onLaunch: {
-				self.sendEvent(withName: "onLaunch", body: [])
-			}, onCompletion: { result in
-				switch result {
-				case .finished(let response):
-					resolve(["finished": response.data])
-				case .closed(let response):
-					resolve(["closed": response.data])
-				case .error:
-					resolve(["error": "Unknown error"])
-				default:
-					print("default")
-					resolve(["error": "Unknown error"])
 				}
-			})
+			)
 		}
 	}
-
+	
 	@objc override func supportedEvents() -> [String] {
-		return ["onInteraction", "onDataRequest", "onLaunch", "onCompletion"]
+		return ["onInteraction", "onDataRequest", "onLaunch", "onCompletion", "onAuthStatusUpdate", "onTaskStatusUpdate"]
 	}
-
+	
 	@objc override static func requiresMainQueueSetup() -> Bool {
-        return true
+		return true
+	}
+}
+
+
+extension TransactCompany {
+	func serialize() -> [String: Any?] {
+		return [
+			"_id": id,
+			"name": name,
+			"branding": branding != nil ? [
+				"color": branding?.color,
+				"logo": [
+					"url": branding?.logo.url,
+					"backgroundColor": branding?.logo.backgroundColor
+				]
+			] : nil
+		]
+	}
+}
+
+extension TransactAuthStatusUpdate {
+    func serialize() -> [String: Any?] {
+        return [
+            "status": status.rawValue,
+            "company": company.serialize(),
+        ]
+    }
+}
+
+extension TransactTaskStatusUpdate {
+    func serialize() -> [String: Any?] {
+        var result: [String: Any?] = [
+            "taskId": taskId,
+            "product": product.rawValue,
+            "status": status.rawValue,
+            "failReason": failReason,
+            "company": company.serialize()
+        ]
+        
+        if let switchData = switchData {
+            var switchMap: [String: Any] = [:]
+            
+            let payment = switchData.paymentMethod
+            var paymentMap: [String: Any] = [
+                "id": payment.id,
+                "title": payment.title,
+                "type": payment.type.rawValue
+            ]
+            
+            switch payment.type {
+            case .card:
+                paymentMap["expiry"] = payment.expiry
+                paymentMap["brand"] = payment.brand
+                paymentMap["lastFour"] = payment.lastFour
+            case .bank:
+                paymentMap["routingNumber"] = payment.routingNumber
+                paymentMap["accountType"] = payment.accountType
+                paymentMap["lastFourAccountNumber"] = payment.lastFourAccountNumber
+            }
+            
+            switchMap["paymentMethod"] = paymentMap
+            result["switchData"] = switchMap
+        }
+        
+        if let depositData = depositData {
+            result["depositData"] = [
+                "accountType": depositData.accountType,
+                "lastFour": depositData.lastFour,
+                "routingNumber": depositData.routingNumber,
+                "title": depositData.title,
+                "distributionAmount": depositData.distributionAmount,
+                "distributionType": depositData.distributionType?.description
+            ]
+        }
+        
+        if let managedBy = managedBy {
+            result["managedBy"] = ["company": managedBy.company.serialize()]
+        }
+        
+        return result
     }
 }

--- a/src/android.tsx
+++ b/src/android.tsx
@@ -20,6 +20,8 @@ export const AtomicAndroid = {
     config,
     environment,
     onInteraction,
+    onTaskStatusUpdate,
+    onAuthStatusUpdate,
     onFinish,
     onDataRequest,
     onClose,
@@ -28,6 +30,8 @@ export const AtomicAndroid = {
     config: any;
     environment?: String;
     onInteraction?: Function;
+    onTaskStatusUpdate?: Function;
+    onAuthStatusUpdate?: Function;
     onDataRequest?: Function;
     onFinish?: Function;
     onClose?: Function;
@@ -42,6 +46,8 @@ export const AtomicAndroid = {
     _addEventListener('onFinish', onFinish);
     _addEventListener('onInteraction', onInteraction);
     _addEventListener('onDataRequest', onDataRequest);
+    _addEventListener('onTaskStatusUpdate', onTaskStatusUpdate);
+    _addEventListener('onAuthStatusUpdate', onAuthStatusUpdate);
 
     const token = Buffer.from(JSON.stringify(config)).toString('base64');
 
@@ -54,6 +60,8 @@ export const AtomicAndroid = {
     onLaunch,
     onFinish,
     onClose,
+    onTaskStatusUpdate,
+    onAuthStatusUpdate,
   }: {
     TransactReactNative: any;
     id: String;
@@ -61,10 +69,14 @@ export const AtomicAndroid = {
     onLaunch?: Function;
     onFinish?: Function;
     onClose?: Function;
+    onTaskStatusUpdate?: Function;
+    onAuthStatusUpdate?: Function;
   }): void {
     _addEventListener('onLaunch', onLaunch);
     _addEventListener('onClose', onClose);
     _addEventListener('onFinish', onFinish);
+    _addEventListener('onTaskStatusUpdate', onTaskStatusUpdate);
+    _addEventListener('onAuthStatusUpdate', onAuthStatusUpdate);
 
     TransactReactNative.presentAction(id, environment);
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,11 +65,15 @@ export const Atomic = {
     onFinish,
     onDataRequest,
     onClose,
+    onAuthStatusUpdate,
+    onTaskStatusUpdate,
   }: {
     config: Config;
     environment?: String;
     onInteraction?: Function;
     onDataRequest?: Function;
+    onAuthStatusUpdate?: Function;
+    onTaskStatusUpdate?: Function;
     onFinish?: Function;
     onClose?: Function;
   }): void {
@@ -88,6 +92,8 @@ export const Atomic = {
       onFinish,
       onDataRequest,
       onClose,
+      onAuthStatusUpdate,
+      onTaskStatusUpdate,
     };
 
     switch (Platform.OS) {
@@ -107,12 +113,16 @@ export const Atomic = {
     onLaunch,
     onFinish,
     onClose,
+    onAuthStatusUpdate,
+    onTaskStatusUpdate,
   }: {
     id: String;
     environment?: String;
     onLaunch?: Function;
     onFinish?: Function;
     onClose?: Function;
+    onAuthStatusUpdate?: Function;
+    onTaskStatusUpdate?: Function;
   }): void {
     const args = {
       TransactReactNative,
@@ -121,6 +131,8 @@ export const Atomic = {
       onLaunch,
       onFinish,
       onClose,
+      onAuthStatusUpdate,
+      onTaskStatusUpdate,
     };
 
     switch (Platform.OS) {

--- a/src/ios.tsx
+++ b/src/ios.tsx
@@ -9,6 +9,8 @@ export const AtomicIOS = {
     onFinish,
     onDataRequest,
     onClose,
+    onAuthStatusUpdate,
+    onTaskStatusUpdate,
   }: {
     TransactReactNative: any;
     config: any;
@@ -17,16 +19,20 @@ export const AtomicIOS = {
     onDataRequest?: Function;
     onFinish?: Function;
     onClose?: Function;
+    onAuthStatusUpdate?: Function;
+    onTaskStatusUpdate?: Function;
   }): void {
     const TransactReactNativeEvents = new NativeEventEmitter(
       TransactReactNative
     );
-    let onInteractionListener: any = undefined;
-    let onDataRequestListener: any = undefined;
+    let onInteractionListener: any;
+    let onDataRequestListener: any;
+    let onAuthStatusUpdateListener: any;
 
     const removeListeners = () => {
       if (onInteractionListener) onInteractionListener.remove();
       if (onDataRequestListener) onDataRequestListener.remove();
+      if (onAuthStatusUpdateListener) onAuthStatusUpdateListener.remove();
     };
 
     if (onInteraction) {
@@ -40,6 +46,20 @@ export const AtomicIOS = {
       onDataRequestListener = TransactReactNativeEvents.addListener(
         'onDataRequest',
         (request) => onDataRequest(request)
+      );
+    }
+
+    if (onAuthStatusUpdate) {
+      onAuthStatusUpdateListener = TransactReactNativeEvents.addListener(
+        'onAuthStatusUpdate',
+        (authStatus) => onAuthStatusUpdate(authStatus)
+      );
+    }
+
+    if (onTaskStatusUpdate) {
+      TransactReactNativeEvents.addListener(
+        'onTaskStatusUpdate',
+        (taskStatus) => onTaskStatusUpdate(taskStatus)
       );
     }
 
@@ -62,6 +82,8 @@ export const AtomicIOS = {
     onLaunch,
     onFinish,
     onClose,
+    onAuthStatusUpdate,
+    onTaskStatusUpdate,
   }: {
     TransactReactNative: any;
     id: String;
@@ -69,20 +91,37 @@ export const AtomicIOS = {
     onLaunch?: Function;
     onFinish?: Function;
     onClose?: Function;
+    onAuthStatusUpdate?: Function;
+    onTaskStatusUpdate?: Function;
   }): void {
     const TransactReactNativeEvents = new NativeEventEmitter(
       TransactReactNative
     );
-
-    let onLaunchListener: any = undefined;
+    let onLaunchListener: any;
+    let onAuthStatusUpdateListener: any;
 
     const removeListeners = () => {
       if (onLaunchListener) onLaunchListener.remove();
+      if (onAuthStatusUpdateListener) onAuthStatusUpdateListener.remove();
     };
 
     if (onLaunch) {
       onLaunchListener = TransactReactNativeEvents.addListener('onLaunch', () =>
         onLaunch()
+      );
+    }
+
+    if (onAuthStatusUpdate) {
+      onAuthStatusUpdateListener = TransactReactNativeEvents.addListener(
+        'onAuthStatusUpdate',
+        (authStatus) => onAuthStatusUpdate(authStatus)
+      );
+    }
+
+    if (onTaskStatusUpdate) {
+      TransactReactNativeEvents.addListener(
+        'onTaskStatusUpdate',
+        (taskStatus) => onTaskStatusUpdate(taskStatus)
       );
     }
 


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/MGMT-493/add-ontaskstatusupdate-and-onauthstatusupdate-to-react-native-sdk

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [ ] New and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
