### PR TITLE
fix: set minimum ios version in transact react native sdk to 13

### DIFF
--- a/atomicfi-transact-react-native.podspec
+++ b/atomicfi-transact-react-native.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "12.0" }
+  s.platforms    = { :ios => "13.0" }
   s.source       = { :git => "https://github.com/atomicfi/atomic-transact-react-native.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicfi/transact-react-native",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "React Native bridge for the Transact SDK",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/MGMT-1009/set-minimum-ios-version-in-transact-react-native-sdk-to-13

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [ ] New and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
