### PR TITLE
chore: trigger npm publish on github release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: node
         uses: actions/setup-node@v3
         with:
@@ -35,12 +35,10 @@ jobs:
 
       - name: Commit version update
         if: github.event_name == 'release'
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add package.json
-          git commit -m "chore: update version to ${{ github.event.release.tag_name }}"
-          git push
+        uses: stefanzweifel/git-auto-commit-action@v6
+        with:
+          commit_message: 'chore: update version to ${{ github.event.release.tag_name }}'
+          file_pattern: package.json
 
       - name: Publish
         run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,13 +33,6 @@ jobs:
             echo "Skipping version update for manual trigger"
           fi
 
-      - name: Commit version update
-        if: github.event_name == 'release'
-        uses: stefanzweifel/git-auto-commit-action@v6
-        with:
-          commit_message: 'chore: update version to ${{ github.event.release.tag_name }}'
-          file_pattern: package.json
-
       - name: Publish
         run: npm publish --access public
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,15 @@
 name: publish
 
 on:
-  push:
-    branches: master
-    paths: package.json
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:
-  npm:
+  publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -23,27 +22,27 @@ jobs:
 
       - name: Install Dependencies
         run: yarn
+      - name: Update package.json version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG_NAME="${{ github.event.release.tag_name }}"
+            VERSION=${TAG_NAME#v}  # Remove 'v' prefix if present
+            npm version $VERSION --no-git-tag-version
+            echo "Updated package.json version to $VERSION"
+          else
+            echo "Skipping version update for manual trigger"
+          fi
+
+      - name: Commit version update
+        if: github.event_name == 'release'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add package.json
+          git commit -m "chore: update version to ${{ github.event.release.tag_name }}"
+          git push
+
       - name: Publish
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
-  tag:
-    needs: npm
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: node
-        uses: actions/setup-node@v3
-      - name: tag
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const { version } = require('./package.json')
-            github.rest.git.createRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: `refs/tags/${version}`,
-                sha: context.sha
-              })

--- a/README.md
+++ b/README.md
@@ -3,3 +3,49 @@
 React Native bridge for the Transact SDK
 
 See our [documentation](https://docs.atomicfi.com/reference/transact-sdk#libraries__react-native) for additional information.
+
+## Release Instructions
+
+This repository uses automated publishing via GitHub releases. When you publish a release, it automatically:
+
+1. ✅ Updates `package.json` version to match the release tag
+2. ✅ Commits the version change back to the repository
+3. ✅ Publishes the package to npm with the correct version
+
+### Creating a Release
+
+1. **Ensure your code is ready for release** on the `master` branch
+
+2. **Create a new release** on GitHub:
+   - Go to [Releases](../../releases) → "Create a new release"
+   - Use the [release template](RELEASE_TEMPLATE.md) for the release notes
+
+3. **Publish the release** - This automatically triggers the publish workflow
+
+### Version Guidelines
+
+- Use [semantic versioning](https://semver.org/): `MAJOR.MINOR.PATCH`
+- Tag format: `1.2.3`
+- For testing: Use pre-release tags like `1.2.3-beta.1`
+
+### What Happens Automatically
+
+When you publish a release:
+
+```
+GitHub Release (1.2.3) → Workflow Triggers → Updates package.json → Commits Changes → Publishes to npm
+```
+
+### Manual Publishing (Fallback)
+
+If needed, you can manually trigger the publish workflow:
+
+1. Go to [Actions](../../actions) → "publish" workflow
+2. Click "Run workflow" → Select branch → "Run workflow"
+3. Note: Manual triggers skip version updates
+
+### Troubleshooting
+
+- **Workflow fails**: Check the [Actions](../../actions) tab for detailed logs
+- **Version conflicts**: Ensure the release tag doesn't already exist on npm
+- **Permission issues**: Verify npm token is properly configured in repository secrets


### PR DESCRIPTION
* automate package version bumps

# Linear Link

https://linear.app/atomicbuilt/issue/SDK-32/react-native-release-publishing-should-be-triggered-by-release

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [ ] New and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
