### PR TITLE
chore: trigger test-app workflow after release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,3 +37,5 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+  update-test-app:
+    uses: ./.github/workflows/update-test-app.yml

--- a/.github/workflows/update-test-app.yml
+++ b/.github/workflows/update-test-app.yml
@@ -1,0 +1,19 @@
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  update-test-app:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sdk-upgrade workflow in test app
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: 'transact-rn-test-app',
+                workflow_id: 'sdk-upgrade.yml',
+                ref: 'main',
+            })
+            console.log(result)


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/SDK-42/automate-react-native-test-app-build-with-sdk-release

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [ ] New and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
