### PR TITLE
chore: bump AtomicSDK version to 3.20.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,5 +37,3 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-  update-test-app:
-    uses: ./.github/workflows/update-test-app.yml

--- a/.github/workflows/update-test-app.yml
+++ b/.github/workflows/update-test-app.yml
@@ -1,6 +1,11 @@
+name: Update Test App
+
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      SDK_TEST_APPS_TOKEN:
+        required: true
 
 jobs:
   update-test-app:
@@ -9,6 +14,7 @@ jobs:
       - name: Trigger sdk-upgrade workflow in test app
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.SDK_TEST_APPS_TOKEN }}
           script: |
             const result = await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,

--- a/atomicfi-transact-react-native.podspec
+++ b/atomicfi-transact-react-native.podspec
@@ -20,13 +20,13 @@ Pod::Spec.new do |s|
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)
-    s.dependency "AtomicSDK", "3.20.3"
+    s.dependency "AtomicSDK", "3.20.5"
     s.pod_target_xcconfig = {
       "DEFINES_MODULE" => "YES",
     }
   else
     s.dependency "React-Core"
-    s.dependency "AtomicSDK", "3.20.3"
+    s.dependency "AtomicSDK", "3.20.5"
 
     # Don't install the dependencies when we run `pod install` in the old architecture.
     if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/SDK-68/release-react-native-sdk-3125

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [ ] New and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
