### PR TITLE
chore: upgrade Android SDK to 3.18.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 // Update this value to the latest Android SDK version published on Maven
-def transact_version = "3.17.1"
+def transact_version = "3.18.1"
 
 android {
   namespace "com.atomicfi.transactreactnative"


### PR DESCRIPTION
Automated upgrade of Android SDK Maven dependency to version 3.18.1.

**Release notes**: https://github.com/atomicfi/atomic-transact-android/releases/tag/3.18.1