### PR TITLE
fix: use latest update-ios-sdk.sh in release-dynamic workflow

### DIFF
--- a/.github/workflows/release-dynamic.yml
+++ b/.github/workflows/release-dynamic.yml
@@ -53,6 +53,24 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      # Static tags from before the --dynamic flag existed ship the old
+      # script, which would treat --dynamic as the version arg and 404. Pull
+      # only the script file from the workflow's own commit so the rest of
+      # the v<version> working tree stays intact for the tag commit below.
+      - name: Restore latest update-ios-sdk.sh
+        env:
+          # github.sha is the commit the workflow file was loaded from
+          # (master HEAD on workflow_dispatch). Pinning to it guarantees the
+          # script matches this workflow even if master moves mid-run.
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          # Fetch is needed because actions/checkout only pulled history
+          # reachable from the static tag.
+          git fetch origin "$WORKFLOW_SHA"
+          # Pathspec form: overwrites just this file in the working tree
+          # without moving HEAD or switching branches.
+          git checkout "$WORKFLOW_SHA" -- scripts/update-ios-sdk.sh
+
       - name: Swap to dynamic xcframeworks
         env:
           STATIC_VERSION: ${{ steps.version.outputs.static_version }}


### PR DESCRIPTION
The workflow checks out the static release tag (e.g. v3.16.0) before running the script, so any tag predating the --dynamic flag's addition ships an old script that treats --dynamic as the version arg and 404s on download. Restore the script from the workflow's commit SHA after checking out the static tag.

# Linear Link

https://linear.app/atomicbuilt/issue/SDK-557/expo-build-issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [ ] New and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
