### PR TITLE
feat: add headless option to presentAction

### DIFF
--- a/android/src/main/java/com/atomicfi/transactreactnative/TransactReactNativeModule.kt
+++ b/android/src/main/java/com/atomicfi/transactreactnative/TransactReactNativeModule.kt
@@ -125,6 +125,7 @@ class TransactReactNativeModule(reactContext: ReactApplicationContext) :
     id: String,
     environment: ReadableMap,
     wrapperVersion: String,
+    headless: Boolean?,
     promise: Promise,
   ) {
     val context = reactApplicationContext.currentActivity as Context
@@ -135,7 +136,8 @@ class TransactReactNativeModule(reactContext: ReactApplicationContext) :
       val config = ActionConfig(
         id = id,
         environment = Config.Environment.CUSTOM,
-        environmentURL = environmentURL
+        environmentURL = environmentURL,
+        headless = headless,
       )
       config.platform = Config.Platform.suffixed("react-$wrapperVersion")
 

--- a/example/screens/PresentActionScreen.tsx
+++ b/example/screens/PresentActionScreen.tsx
@@ -33,6 +33,7 @@ const PresentActionScreen: React.FC<Props> = () => {
   const [presentationStyleIOS, setPresentationStyleIOS] =
     useState<PresentationStyleIOS>(PresentationStyles.formSheet);
   const [debugEnabled, setDebugEnabled] = useState(false);
+  const [headless, setHeadless] = useState(false);
 
   const environmentOptions = [
     { key: 'sandbox' as EnvironmentOption, label: 'Sandbox' },
@@ -88,6 +89,7 @@ const PresentActionScreen: React.FC<Props> = () => {
       environment: getEnvironment(),
       presentationStyleIOS,
       setDebug: debugEnabled,
+      headless,
       onLaunch: () => {
         console.log('Action launched');
         setIsLoading(false);
@@ -183,6 +185,22 @@ const PresentActionScreen: React.FC<Props> = () => {
             <Switch
               value={debugEnabled}
               onValueChange={setDebugEnabled}
+              trackColor={{ false: '#d1d5db', true: '#3b82f6' }}
+              thumbColor="#fff"
+            />
+            <Text style={styles.switchLabel}>On</Text>
+          </View>
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Headless</Text>
+        <View style={styles.switchGroup}>
+          <View style={styles.switchContainer}>
+            <Text style={styles.switchLabel}>Off</Text>
+            <Switch
+              value={headless}
+              onValueChange={setHeadless}
               trackColor={{ false: '#d1d5db', true: '#3b82f6' }}
               thumbColor="#fff"
             />

--- a/ios/TransactReactNative.m
+++ b/ios/TransactReactNative.m
@@ -16,6 +16,7 @@ RCT_EXTERN_METHOD(presentAction:(NSString *)id
 				  environment:(NSDictionary *)environment
 				  presentationStyle:(nullable NSString *)presentationStyle
 				  setDebug:(nullable NSNumber *)setDebug
+				  headless:(nullable NSNumber *)headless
 				  withResolver:(RCTPromiseResolveBlock)resolve
 				  withRejecter:(RCTPromiseRejectBlock)reject)
 

--- a/ios/TransactReactNative.swift
+++ b/ios/TransactReactNative.swift
@@ -133,9 +133,10 @@ class TransactReactNative: RCTEventEmitter {
 		}
 	}
 	
-	@objc(presentAction:environment:presentationStyle:setDebug:withResolver:withRejecter:)
-	func presentAction(id: String, environment: [String: Any], presentationStyle: String?, setDebug: NSNumber?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+	@objc(presentAction:environment:presentationStyle:setDebug:headless:withResolver:withRejecter:)
+	func presentAction(id: String, environment: [String: Any], presentationStyle: String?, setDebug: NSNumber?, headless: NSNumber?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
 		let debugEnabled = setDebug?.boolValue ?? false
+		let headlessEnabled = headless?.boolValue ?? false
 
 		Task { @MainActor in
 			await Atomic.setDebug(isEnabled: debugEnabled, forwardLogs: { logMessage in
@@ -152,6 +153,7 @@ class TransactReactNative: RCTEventEmitter {
 				id: id,
 				environment: parsedEnvironment,
 				presentationStyle: parsedPresentationStyle,
+				headless: headlessEnabled,
 				onLaunch: {
 					self.sendEvent(withName: "onLaunch", body: [])
 				},

--- a/src/android.tsx
+++ b/src/android.tsx
@@ -52,6 +52,7 @@ export const AtomicAndroid = {
     id,
     environment,
     wrapperVersion,
+    headless,
     onLaunch,
     onFinish,
     onClose,
@@ -62,6 +63,7 @@ export const AtomicAndroid = {
     id: String;
     environment?: CONSTANTS.TransactEnvironment;
     wrapperVersion: string;
+    headless?: boolean;
     onLaunch?: Function;
     onFinish?: Function;
     onClose?: Function;
@@ -74,6 +76,11 @@ export const AtomicAndroid = {
     _addEventListener('onTaskStatusUpdate', onTaskStatusUpdate);
     _addEventListener('onAuthStatusUpdate', onAuthStatusUpdate);
 
-    TransactReactNative.presentAction(id, environment, wrapperVersion);
+    TransactReactNative.presentAction(
+      id,
+      environment,
+      wrapperVersion,
+      headless
+    );
   },
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -155,6 +155,7 @@ export const Atomic = {
     id,
     environment,
     presentationStyleIOS,
+    headless,
     onLaunch,
     onFinish,
     onClose,
@@ -165,6 +166,7 @@ export const Atomic = {
     id: String;
     environment?: CONSTANTS.TransactEnvironment;
     presentationStyleIOS?: PresentationStyleIOS;
+    headless?: boolean;
     onLaunch?: Function;
     onFinish?: Function;
     onClose?: Function;
@@ -178,6 +180,7 @@ export const Atomic = {
       environment: environment || CONSTANTS.Environment.production,
       wrapperVersion,
       presentationStyleIOS,
+      headless,
       onLaunch,
       onFinish,
       onClose,

--- a/src/ios.tsx
+++ b/src/ios.tsx
@@ -115,6 +115,7 @@ export const AtomicIOS = {
     id,
     environment,
     presentationStyleIOS,
+    headless,
     onLaunch,
     onFinish,
     onClose,
@@ -129,6 +130,7 @@ export const AtomicIOS = {
     // for parity with Android callers but not forwarded to native.
     wrapperVersion?: string;
     presentationStyleIOS?: CONSTANTS.PresentationStyleIOS;
+    headless?: boolean;
     onLaunch?: Function;
     onFinish?: Function;
     onClose?: Function;
@@ -180,7 +182,8 @@ export const AtomicIOS = {
       id,
       environment,
       presentationStyleIOS,
-      setDebug
+      setDebug,
+      headless
     ).then((event: any) => {
       if (event.finished && onFinish) {
         removeListeners();


### PR DESCRIPTION
- Add optional headless?: boolean to Atomic.presentAction
- Forward headless through iOS native module to Atomic.presentAction
- Forward headless through Android native module to ActionConfig
- Add headless toggle to example PresentActionScreen

# Linear Link

https://linear.app/atomicbuilt/issue/MGMT-2044/add-headless-option-in-react-native-sdk

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [x] New and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
