### PR TITLE
fix(ios): add actionType to task status update callback

### DIFF
--- a/ios/TransactReactNative.swift
+++ b/ios/TransactReactNative.swift
@@ -233,7 +233,8 @@ extension TransactTaskStatusUpdate {
             "product": product.rawValue,
             "status": status.rawValue,
             "failReason": failReason,
-            "company": company.serialize()
+            "company": company.serialize(),
+            "actionType": actionType?.rawValue
         ]
         
         if let switchData = switchData {


### PR DESCRIPTION

<img width="863" height="61" alt="CleanShot 2026-05-12 at 12 08 51" src="https://github.com/user-attachments/assets/4ae2a75c-5516-4599-9074-783070306055" />


# Linear Link

https://linear.app/atomicbuilt/issue/SDK-594/add-actiontype-to-task-status-update-in-rn-sdk

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [x] New and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
