### PR TITLE
refactor(actions): manage actions called from Atomic.transact

### DIFF
--- a/android/src/main/java/com/atomicfi/transactreactnative/TransactReactNativeModule.kt
+++ b/android/src/main/java/com/atomicfi/transactreactnative/TransactReactNativeModule.kt
@@ -5,7 +5,6 @@ import android.util.Base64
 import com.facebook.react.bridge.*
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import financial.atomic.transact.Config
-import financial.atomic.transact.ActionConfig
 import financial.atomic.transact.Transact
 import financial.atomic.transact.receiver.TransactBroadcastReceiver
 import org.json.JSONObject
@@ -96,6 +95,10 @@ class TransactReactNativeModule(reactContext: ReactApplicationContext) :
           handleCallbackEvent("onFinish", data, "taskId", emitter, promise)
         }
 
+        override fun onLaunch() {
+          emitter.emit("onLaunch", null)
+        }
+
         override fun onInteraction(data: JSONObject) {
           emitter.emit("onInteraction", data.toString())
         }
@@ -115,60 +118,6 @@ class TransactReactNativeModule(reactContext: ReactApplicationContext) :
           emitter.emit("onTaskStatusUpdate", data.toString())
         }
       })
-    } catch (e: Exception) {
-      promise.reject(e)
-    }
-  }
-
-  @ReactMethod
-  fun presentAction(
-    id: String,
-    environment: ReadableMap,
-    wrapperVersion: String,
-    headless: Boolean?,
-    promise: Promise,
-  ) {
-    val context = reactApplicationContext.currentActivity as Context
-    val emitter = reactApplicationContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-    val environmentURL = parseEnvironment(environment)
-
-    try {
-      val config = ActionConfig(
-        id = id,
-        environment = Config.Environment.CUSTOM,
-        environmentURL = environmentURL,
-        headless = headless,
-      )
-      config.platform = Config.Platform.suffixed("react-$wrapperVersion")
-
-      Transact.presentAction(context, config)
-
-      val receiver = object : TransactBroadcastReceiver() {
-        override fun onClose(data: JSONObject) {
-          handleCallbackEvent("onClose", data, "reason", emitter, promise)
-        }
-
-        override fun onFinish(data: JSONObject) {
-          handleCallbackEvent("onFinish", data, "taskId", emitter, promise)
-        }
-
-        override fun onLaunch() {
-          emitter.emit("onLaunch", null)
-        }
-
-        override fun onAuthStatusUpdate(data: JSONObject) {
-          emitter.emit("onAuthStatusUpdate", data.toString())
-        }
-
-        override fun onTaskStatusUpdate(data: JSONObject) {
-          if (!data.has("failReason")) {
-            data.put("failReason", JSONObject.NULL)
-          }
-          emitter.emit("onTaskStatusUpdate", data.toString())
-        }
-      }
-
-      Transact.registerReceiver(context, receiver)
     } catch (e: Exception) {
       promise.reject(e)
     }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -3,12 +3,12 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import HomeScreen from './screens/HomeScreen';
 import TransactScreen from './screens/TransactScreen';
-import PresentActionScreen from './screens/PresentActionScreen';
+import ActionScreen from './screens/ActionScreen';
 
 export type RootStackParamList = {
   Home: undefined;
   Transact: undefined;
-  PresentAction: undefined;
+  Action: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -40,9 +40,9 @@ export default function App() {
             options={{ title: 'Transact Demo' }}
           />
           <Stack.Screen
-            name="PresentAction"
-            component={PresentActionScreen}
-            options={{ title: 'Present Action Demo' }}
+            name="Action"
+            component={ActionScreen}
+            options={{ title: 'Action Demo' }}
           />
         </Stack.Navigator>
       </NavigationContainer>

--- a/example/screens/ActionScreen.tsx
+++ b/example/screens/ActionScreen.tsx
@@ -16,14 +16,16 @@ import {
   Atomic,
   Environment,
   PresentationStyles,
+  Scope,
 } from '@atomicfi/transact-react-native';
 import type { PresentationStyleIOS } from '@atomicfi/transact-react-native';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'PresentAction'>;
+type Props = NativeStackScreenProps<RootStackParamList, 'Action'>;
 
 type EnvironmentOption = 'sandbox' | 'production' | 'custom';
 
-const PresentActionScreen: React.FC<Props> = () => {
+const ActionScreen: React.FC<Props> = () => {
+  const [publicToken, setPublicToken] = useState('');
   const [actionId, setActionId] = useState('');
   const [selectedEnvironment, setSelectedEnvironment] =
     useState<EnvironmentOption>('sandbox');
@@ -65,7 +67,12 @@ const PresentActionScreen: React.FC<Props> = () => {
     }
   };
 
-  const presentAction = () => {
+  const launchAction = () => {
+    if (!publicToken.trim()) {
+      Alert.alert('Error', 'Please enter a valid public token');
+      return;
+    }
+
     if (!actionId.trim()) {
       Alert.alert('Error', 'Please enter a valid action ID');
       return;
@@ -84,12 +91,21 @@ const PresentActionScreen: React.FC<Props> = () => {
 
     setIsLoading(true);
 
-    Atomic.presentAction({
-      id: actionId.trim(),
+    Atomic.transact({
+      config: {
+        publicToken: publicToken.trim(),
+        scope: Scope.PAYLINK,
+        tasks: [
+          {
+            operation: 'action',
+            action: { id: actionId.trim() },
+            headless,
+          },
+        ],
+      },
       environment: getEnvironment(),
       presentationStyleIOS,
       setDebug: debugEnabled,
-      headless,
       onLaunch: () => {
         console.log('Action launched');
         setIsLoading(false);
@@ -114,14 +130,27 @@ const PresentActionScreen: React.FC<Props> = () => {
   return (
     <ScrollView style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.headerTitle}>Present Action</Text>
+        <Text style={styles.headerTitle}>Action</Text>
         <Text style={styles.headerSubtitle}>
-          Launch specific Atomic actions by ID
+          Launch a specific Atomic action through transact()
         </Text>
       </View>
 
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>Configuration</Text>
+
+        <View style={styles.inputGroup}>
+          <Text style={styles.label}>Public Token *</Text>
+          <TextInput
+            style={styles.input}
+            value={publicToken}
+            onChangeText={setPublicToken}
+            placeholder="Enter your public token"
+            placeholderTextColor="#9ca3af"
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </View>
 
         <View style={styles.inputGroup}>
           <Text style={styles.label}>Action ID *</Text>
@@ -131,6 +160,8 @@ const PresentActionScreen: React.FC<Props> = () => {
             onChangeText={setActionId}
             placeholder="Enter action ID (e.g., action-123)"
             placeholderTextColor="#9ca3af"
+            autoCapitalize="none"
+            autoCorrect={false}
           />
         </View>
 
@@ -213,8 +244,9 @@ const PresentActionScreen: React.FC<Props> = () => {
         <Text style={styles.sectionTitle}>How it works</Text>
         <View style={styles.infoCard}>
           <Text style={styles.infoText}>
-            Present Action allows you to launch specific Atomic actions by their
-            ID. This is useful for:
+            Actions are launched through Atomic.transact() with a task whose
+            operation is &quot;action&quot;. The action ID is supplied on the
+            task and the public token in the config. Use this for:
           </Text>
           <Text style={styles.bulletPoint}>
             • Launching pre-configured flows
@@ -258,11 +290,11 @@ const PresentActionScreen: React.FC<Props> = () => {
       <View style={styles.buttonContainer}>
         <TouchableOpacity
           style={[styles.launchButton, isLoading && styles.disabledButton]}
-          onPress={presentAction}
+          onPress={launchAction}
           disabled={isLoading}
         >
           <Text style={styles.launchButtonText}>
-            {isLoading ? 'Launching...' : 'Present Action'}
+            {isLoading ? 'Launching...' : 'Launch Action'}
           </Text>
         </TouchableOpacity>
       </View>
@@ -441,4 +473,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default PresentActionScreen;
+export default ActionScreen;

--- a/example/screens/HomeScreen.tsx
+++ b/example/screens/HomeScreen.tsx
@@ -19,7 +19,7 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
       'This example app demonstrates the integration of the @atomicfi/transact-react-native package.\n\n' +
         'Features:\n' +
         '• Transact Flow - Complete financial connection flow\n' +
-        '• Present Action - Launch specific actions\n' +
+        '• Action - Launch a specific action through transact()\n' +
         '• Environment switching (Sandbox/Production)\n' +
         '• Custom theming and configuration\n\n' +
         'Note: You need valid Atomic credentials to test the actual flows.',
@@ -47,11 +47,11 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
 
         <TouchableOpacity
           style={[styles.button, styles.secondaryButton]}
-          onPress={() => navigation.navigate('PresentAction')}
+          onPress={() => navigation.navigate('Action')}
         >
-          <Text style={styles.buttonText}>Present Action</Text>
+          <Text style={styles.buttonText}>Launch Action</Text>
           <Text style={styles.buttonSubtext}>
-            Launch specific actions by ID
+            Launch a specific action through transact()
           </Text>
         </TouchableOpacity>
 

--- a/ios/TransactReactNative.m
+++ b/ios/TransactReactNative.m
@@ -12,14 +12,6 @@ RCT_EXTERN_METHOD(presentTransact:(NSDictionary *)config
 				  withResolver:(RCTPromiseResolveBlock)resolve
 				  withRejecter:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(presentAction:(NSString *)id
-				  environment:(NSDictionary *)environment
-				  presentationStyle:(nullable NSString *)presentationStyle
-				  setDebug:(nullable NSNumber *)setDebug
-				  headless:(nullable NSNumber *)headless
-				  withResolver:(RCTPromiseResolveBlock)resolve
-				  withRejecter:(RCTPromiseRejectBlock)reject)
-
 RCT_EXTERN_METHOD(resolveDataRequest:(id)data)
 
 RCT_EXTERN_METHOD(hideTransact:(RCTPromiseResolveBlock)resolve

--- a/ios/TransactReactNative.swift
+++ b/ios/TransactReactNative.swift
@@ -101,6 +101,9 @@ class TransactReactNative: RCTEventEmitter {
 					onTaskStatusUpdate: { status in
 						self.sendEvent(withName: "onTaskStatusUpdate", body: status.serialize())
 					},
+					onLaunch: {
+						self.sendEvent(withName: "onLaunch", body: [])
+					},
 					onCompletion: { result in
 						switch result {
 						case .finished(let response):
@@ -120,66 +123,19 @@ class TransactReactNative: RCTEventEmitter {
 			}
 		}
 	}
-	
+
 	// Method to receive response from React Native
 	@objc(resolveDataRequest:)
 	func resolveDataRequest(data: Any) -> Void {
 		// Call the stored response handler with the data from React Native
 		if let handler = dataResponseHandler {
 			handler(data)
-			
+
 			// Clear the handler
 			dataResponseHandler = nil
 		}
 	}
-	
-	@objc(presentAction:environment:presentationStyle:setDebug:headless:withResolver:withRejecter:)
-	func presentAction(id: String, environment: [String: Any], presentationStyle: String?, setDebug: NSNumber?, headless: NSNumber?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
-		let debugEnabled = setDebug?.boolValue ?? false
-		let headlessEnabled = headless?.boolValue ?? false
 
-		Task { @MainActor in
-			await Atomic.setDebug(isEnabled: debugEnabled, forwardLogs: { logMessage in
-				self.sendEvent(withName: "onDebugLog", body: ["message": logMessage])
-			})
-
-			guard let source = RCTPresentedViewController() else { return }
-
-			let parsedEnvironment = self.parseEnvironment(environment)
-			let parsedPresentationStyle = self.parsePresentationStyle(presentationStyle)
-
-			Atomic.presentAction(
-				from: source,
-				id: id,
-				environment: parsedEnvironment,
-				presentationStyle: parsedPresentationStyle,
-				headless: headlessEnabled,
-				onLaunch: {
-					self.sendEvent(withName: "onLaunch", body: [])
-				},
-				onAuthStatusUpdate: { status in
-					self.sendEvent(withName: "onAuthStatusUpdate", body: status.serialize())
-				},
-				onTaskStatusUpdate: { status in
-					self.sendEvent(withName: "onTaskStatusUpdate", body: status.serialize())
-				},
-				onCompletion: { result in
-					switch result {
-					case .finished(let response):
-						resolve(["finished": response.data])
-					case .closed(let response):
-						resolve(["closed": response.data])
-					case .error:
-						resolve(["error": "Unknown error"])
-					default:
-						print("default")
-						resolve(["error": "Unknown error"])
-					}
-				}
-			)
-		}
-	}
-	
 	@objc(hideTransact:withRejecter:)
 	func hideTransact(resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
 		DispatchQueue.main.async {

--- a/src/android.tsx
+++ b/src/android.tsx
@@ -21,6 +21,7 @@ export const AtomicAndroid = {
     environment,
     wrapperVersion,
     onInteraction,
+    onLaunch,
     onTaskStatusUpdate,
     onAuthStatusUpdate,
     onFinish,
@@ -32,6 +33,7 @@ export const AtomicAndroid = {
     environment?: CONSTANTS.TransactEnvironment;
     wrapperVersion: string;
     onInteraction?: Function;
+    onLaunch?: Function;
     onTaskStatusUpdate?: Function;
     onAuthStatusUpdate?: Function;
     onDataRequest?: Function;
@@ -40,47 +42,12 @@ export const AtomicAndroid = {
   }): void {
     _addEventListener('onClose', onClose);
     _addEventListener('onFinish', onFinish);
+    _addEventListener('onLaunch', onLaunch);
     _addEventListener('onInteraction', onInteraction);
     _addEventListener('onDataRequest', onDataRequest);
     _addEventListener('onTaskStatusUpdate', onTaskStatusUpdate);
     _addEventListener('onAuthStatusUpdate', onAuthStatusUpdate);
 
     TransactReactNative.presentTransact(config, environment, wrapperVersion);
-  },
-  presentAction({
-    TransactReactNative,
-    id,
-    environment,
-    wrapperVersion,
-    headless,
-    onLaunch,
-    onFinish,
-    onClose,
-    onTaskStatusUpdate,
-    onAuthStatusUpdate,
-  }: {
-    TransactReactNative: any;
-    id: String;
-    environment?: CONSTANTS.TransactEnvironment;
-    wrapperVersion: string;
-    headless?: boolean;
-    onLaunch?: Function;
-    onFinish?: Function;
-    onClose?: Function;
-    onTaskStatusUpdate?: Function;
-    onAuthStatusUpdate?: Function;
-  }): void {
-    _addEventListener('onLaunch', onLaunch);
-    _addEventListener('onClose', onClose);
-    _addEventListener('onFinish', onFinish);
-    _addEventListener('onTaskStatusUpdate', onTaskStatusUpdate);
-    _addEventListener('onAuthStatusUpdate', onAuthStatusUpdate);
-
-    TransactReactNative.presentAction(
-      id,
-      environment,
-      wrapperVersion,
-      headless
-    );
   },
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,10 +37,12 @@ interface Theme {
 
 interface Task {
   product?: String; // Deprecated
-  operation: String;
+  operation?: String;
   distribution?: Object;
   navigationOptions?: Object;
   apps?: AppType[];
+  action?: { id: String };
+  headless?: boolean;
 }
 
 interface Customer {
@@ -99,6 +101,7 @@ export const Atomic = {
     config,
     environment,
     onInteraction,
+    onLaunch,
     onFinish,
     onDataRequest,
     onClose,
@@ -113,6 +116,7 @@ export const Atomic = {
     onDataRequest?: Function;
     onAuthStatusUpdate?: Function;
     onTaskStatusUpdate?: Function;
+    onLaunch?: Function;
     onFinish?: Function;
     onClose?: Function;
     presentationStyleIOS?: PresentationStyleIOS;
@@ -131,6 +135,7 @@ export const Atomic = {
       environment: environment || CONSTANTS.Environment.production,
       wrapperVersion,
       onInteraction,
+      onLaunch,
       onFinish,
       onDataRequest,
       onClose,
@@ -146,55 +151,6 @@ export const Atomic = {
         break;
       case 'android':
         AtomicAndroid.transact(args);
-        break;
-      default:
-        throw new Error(`Unsupported OS: ${Platform.OS}`);
-    }
-  },
-  presentAction({
-    id,
-    environment,
-    presentationStyleIOS,
-    headless,
-    onLaunch,
-    onFinish,
-    onClose,
-    onAuthStatusUpdate,
-    onTaskStatusUpdate,
-    setDebug,
-  }: {
-    id: String;
-    environment?: CONSTANTS.TransactEnvironment;
-    presentationStyleIOS?: PresentationStyleIOS;
-    headless?: boolean;
-    onLaunch?: Function;
-    onFinish?: Function;
-    onClose?: Function;
-    onAuthStatusUpdate?: Function;
-    onTaskStatusUpdate?: Function;
-    setDebug?: boolean;
-  }): void {
-    const args = {
-      TransactReactNative,
-      id,
-      environment: environment || CONSTANTS.Environment.production,
-      wrapperVersion,
-      presentationStyleIOS,
-      headless,
-      onLaunch,
-      onFinish,
-      onClose,
-      onAuthStatusUpdate,
-      onTaskStatusUpdate,
-      setDebug,
-    };
-
-    switch (Platform.OS) {
-      case 'ios':
-        AtomicIOS.presentAction(args);
-        break;
-      case 'android':
-        AtomicAndroid.presentAction(args);
         break;
       default:
         throw new Error(`Unsupported OS: ${Platform.OS}`);

--- a/src/ios.tsx
+++ b/src/ios.tsx
@@ -8,6 +8,7 @@ export const AtomicIOS = {
     environment,
     wrapperVersion,
     onInteraction,
+    onLaunch,
     onFinish,
     onDataRequest,
     onClose,
@@ -22,6 +23,7 @@ export const AtomicIOS = {
     wrapperVersion: string;
     onInteraction?: Function;
     onDataRequest?: Function;
+    onLaunch?: Function;
     onFinish?: Function;
     onClose?: Function;
     onAuthStatusUpdate?: Function;
@@ -34,12 +36,14 @@ export const AtomicIOS = {
     );
     let onInteractionListener: any;
     let onDataRequestListener: any;
+    let onLaunchListener: any;
     let onAuthStatusUpdateListener: any;
     let onDebugLogListener: any;
 
     const removeListeners = () => {
       if (onInteractionListener) onInteractionListener.remove();
       if (onDataRequestListener) onDataRequestListener.remove();
+      if (onLaunchListener) onLaunchListener.remove();
       if (onAuthStatusUpdateListener) onAuthStatusUpdateListener.remove();
       if (onDebugLogListener) onDebugLogListener.remove();
     };
@@ -80,84 +84,6 @@ export const AtomicIOS = {
       );
     }
 
-    if (onAuthStatusUpdate) {
-      onAuthStatusUpdateListener = TransactReactNativeEvents.addListener(
-        'onAuthStatusUpdate',
-        (authStatus) => onAuthStatusUpdate(authStatus)
-      );
-    }
-
-    if (onTaskStatusUpdate) {
-      TransactReactNativeEvents.addListener(
-        'onTaskStatusUpdate',
-        (taskStatus) => onTaskStatusUpdate(taskStatus)
-      );
-    }
-
-    TransactReactNative.presentTransact(
-      config,
-      environment,
-      presentationStyleIOS,
-      setDebug,
-      wrapperVersion
-    ).then((event: any) => {
-      if (event.finished && onFinish) {
-        removeListeners();
-        onFinish(event.finished);
-      } else if (event.closed && onClose) {
-        removeListeners();
-        onClose(event.closed);
-      }
-    });
-  },
-  presentAction({
-    TransactReactNative,
-    id,
-    environment,
-    presentationStyleIOS,
-    headless,
-    onLaunch,
-    onFinish,
-    onClose,
-    onAuthStatusUpdate,
-    onTaskStatusUpdate,
-    setDebug,
-  }: {
-    TransactReactNative: any;
-    id: String;
-    environment?: CONSTANTS.TransactEnvironment;
-    // iOS `presentAction` does not yet accept a platform suffix; accepted here
-    // for parity with Android callers but not forwarded to native.
-    wrapperVersion?: string;
-    presentationStyleIOS?: CONSTANTS.PresentationStyleIOS;
-    headless?: boolean;
-    onLaunch?: Function;
-    onFinish?: Function;
-    onClose?: Function;
-    onAuthStatusUpdate?: Function;
-    onTaskStatusUpdate?: Function;
-    setDebug?: boolean;
-  }): void {
-    const TransactReactNativeEvents = new NativeEventEmitter(
-      TransactReactNative
-    );
-    let onLaunchListener: any;
-    let onAuthStatusUpdateListener: any;
-    let onDebugLogListener: any;
-
-    const removeListeners = () => {
-      if (onLaunchListener) onLaunchListener.remove();
-      if (onAuthStatusUpdateListener) onAuthStatusUpdateListener.remove();
-      if (onDebugLogListener) onDebugLogListener.remove();
-    };
-
-    onDebugLogListener = TransactReactNativeEvents.addListener(
-      'onDebugLog',
-      (log) => {
-        console.debug('[TransactNative]', log.message);
-      }
-    );
-
     if (onLaunch) {
       onLaunchListener = TransactReactNativeEvents.addListener('onLaunch', () =>
         onLaunch()
@@ -178,12 +104,12 @@ export const AtomicIOS = {
       );
     }
 
-    TransactReactNative.presentAction(
-      id,
+    TransactReactNative.presentTransact(
+      config,
       environment,
       presentationStyleIOS,
       setDebug,
-      headless
+      wrapperVersion
     ).then((event: any) => {
       if (event.finished && onFinish) {
         removeListeners();


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/SDK-600/rn-transact-action-should-be-called-with-atomictransact

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change which cleans up code)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [x] New and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
