### PR TITLE
fix(ios): duplicate callbacks registered

### DIFF
--- a/src/ios.tsx
+++ b/src/ios.tsx
@@ -34,75 +34,54 @@ export const AtomicIOS = {
     const TransactReactNativeEvents = new NativeEventEmitter(
       TransactReactNative
     );
-    let onInteractionListener: any;
-    let onDataRequestListener: any;
-    let onLaunchListener: any;
-    let onAuthStatusUpdateListener: any;
-    let onDebugLogListener: any;
 
-    const removeListeners = () => {
-      if (onInteractionListener) onInteractionListener.remove();
-      if (onDataRequestListener) onDataRequestListener.remove();
-      if (onLaunchListener) onLaunchListener.remove();
-      if (onAuthStatusUpdateListener) onAuthStatusUpdateListener.remove();
-      if (onDebugLogListener) onDebugLogListener.remove();
+    const setListener = (event: string, handler?: Function) => {
+      TransactReactNativeEvents.removeAllListeners(event);
+      if (handler) {
+        TransactReactNativeEvents.addListener(event, (payload) =>
+          handler(payload)
+        );
+      }
     };
 
-    onDebugLogListener = TransactReactNativeEvents.addListener(
-      'onDebugLog',
-      (log) => {
-        console.debug('[TransactNative]', log.message);
-      }
+    setListener('onDebugLog', (log: any) => {
+      console.debug('[TransactNative]', log.message);
+    });
+
+    setListener(
+      'onInteraction',
+      onInteraction && ((interaction: any) => onInteraction(interaction))
     );
 
-    if (onInteraction) {
-      onInteractionListener = TransactReactNativeEvents.addListener(
-        'onInteraction',
-        (interaction) => onInteraction(interaction)
-      );
-    }
-
-    if (onDataRequest) {
-      onDataRequestListener = TransactReactNativeEvents.addListener(
-        'onDataRequest',
-        async (request) => {
+    setListener(
+      'onDataRequest',
+      onDataRequest &&
+        (async (request: any) => {
           try {
-            // Call the user's onDataRequest handler
             const response = await onDataRequest(request);
-
-            // Send the response back to native code
             TransactReactNative.resolveDataRequest(response);
-
             return response;
           } catch (error) {
             console.error('## Error in onDataRequest:', error);
-            // Send null as response in case of error
             TransactReactNative.resolveDataRequest(null);
             return null;
           }
-        }
-      );
-    }
+        })
+    );
 
-    if (onLaunch) {
-      onLaunchListener = TransactReactNativeEvents.addListener('onLaunch', () =>
-        onLaunch()
-      );
-    }
+    setListener('onLaunch', onLaunch && (() => onLaunch()));
 
-    if (onAuthStatusUpdate) {
-      onAuthStatusUpdateListener = TransactReactNativeEvents.addListener(
-        'onAuthStatusUpdate',
-        (authStatus) => onAuthStatusUpdate(authStatus)
-      );
-    }
+    setListener(
+      'onAuthStatusUpdate',
+      onAuthStatusUpdate &&
+        ((authStatus: any) => onAuthStatusUpdate(authStatus))
+    );
 
-    if (onTaskStatusUpdate) {
-      TransactReactNativeEvents.addListener(
-        'onTaskStatusUpdate',
-        (taskStatus) => onTaskStatusUpdate(taskStatus)
-      );
-    }
+    setListener(
+      'onTaskStatusUpdate',
+      onTaskStatusUpdate &&
+        ((taskStatus: any) => onTaskStatusUpdate(taskStatus))
+    );
 
     TransactReactNative.presentTransact(
       config,
@@ -112,10 +91,8 @@ export const AtomicIOS = {
       wrapperVersion
     ).then((event: any) => {
       if (event.finished && onFinish) {
-        removeListeners();
         onFinish(event.finished);
       } else if (event.closed && onClose) {
-        removeListeners();
         onClose(event.closed);
       }
     });


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/SDK-609/callback-events-fire-multiple-times

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [ ] New and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery
