### PR TITLE
feat: add Android debug flag and onDebugLog support (SDK-680)

### DIFF
--- a/android/src/main/java/com/atomicfi/transactreactnative/TransactReactNativeModule.kt
+++ b/android/src/main/java/com/atomicfi/transactreactnative/TransactReactNativeModule.kt
@@ -78,13 +78,14 @@ class TransactReactNativeModule(reactContext: ReactApplicationContext) :
     config: ReadableMap,
     environment: ReadableMap,
     wrapperVersion: String,
+    setDebug: Boolean,
     promise: Promise,
   ) {
     val context = reactApplicationContext.currentActivity as Context
     val emitter = reactApplicationContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
     val environmentURL = parseEnvironment(environment)
     val token = buildConfigToken(config, wrapperVersion)
-    val sdkConfig = Config(token = token, environment = "CUSTOM", environmentURL = environmentURL)
+    val sdkConfig = Config(token = token, environment = "CUSTOM", environmentURL = environmentURL, debug = setDebug)
 
     UiThreadUtil.runOnUiThread {
       try {
@@ -118,6 +119,15 @@ class TransactReactNativeModule(reactContext: ReactApplicationContext) :
               data.put("failReason", JSONObject.NULL)
             }
             emitter.emit("onTaskStatusUpdate", data.toString())
+          }
+
+          override fun onDebugLog(
+            level: String,
+            tag: String,
+            message: String,
+            data: JSONObject
+          ) {
+            emitter.emit("onDebugLog", data.toString())
           }
         })
       } catch (e: Exception) {

--- a/src/android.tsx
+++ b/src/android.tsx
@@ -27,6 +27,7 @@ export const AtomicAndroid = {
     onFinish,
     onDataRequest,
     onClose,
+    setDebug,
   }: {
     TransactReactNative: any;
     config: any;
@@ -39,7 +40,11 @@ export const AtomicAndroid = {
     onDataRequest?: Function;
     onFinish?: Function;
     onClose?: Function;
+    setDebug?: boolean;
   }): void {
+    _addEventListener('onDebugLog', (log: any) => {
+      console.debug('[TransactNative]', log.message);
+    });
     _addEventListener('onClose', onClose);
     _addEventListener('onFinish', onFinish);
     _addEventListener('onLaunch', onLaunch);
@@ -48,6 +53,11 @@ export const AtomicAndroid = {
     _addEventListener('onTaskStatusUpdate', onTaskStatusUpdate);
     _addEventListener('onAuthStatusUpdate', onAuthStatusUpdate);
 
-    TransactReactNative.presentTransact(config, environment, wrapperVersion);
+    TransactReactNative.presentTransact(
+      config,
+      environment,
+      wrapperVersion,
+      setDebug ?? false
+    );
   },
 };


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/SDK-680

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [x] New and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
    - A01:2021-Broken Access Control
    - A02:2021-Cryptographic Failures
    - A03:2021-Injection
    - A04:2021-Insecure Design
    - A05:2021-Security Misconfiguration
    - A06:2021-Vulnerable and Outdated Components
    - A07:2021-Identification and Authentication Failures
    - A08:2021-Software and Data Integrity Failures
    - A09:2021-Security Logging and Monitoring Failures
    - A10:2021-Server-Side Request Forgery

---

## Summary

Adds Android support for the debug flag, bringing it to parity with the existing iOS `setDebug` support. The example app and JS API already sent `setDebug`; only the Android bridge was dropping it, and Android had no `onDebugLog` equivalent.
